### PR TITLE
Use std strings + use ifstream to parse configuration

### DIFF
--- a/extension.cpp
+++ b/extension.cpp
@@ -95,7 +95,7 @@ bool Cleaner::SDK_OnLoad(char *error, size_t maxlength, bool late)
 		if (fgets(temp, 128, file) != NULL)
 		{
 			// make things a little easier on ourselves
-			std::string thisstring = string(temp);
+			std::string thisstring = temp;
 
 			// significantly more robust way of stripping evil chars from our string so we don't crash
 			// when we try to strip them. this includes newlines, control chars, non ascii unicde, etc.

--- a/extension.cpp
+++ b/extension.cpp
@@ -90,6 +90,7 @@ bool Cleaner::SDK_OnLoad(char *error, size_t maxlength, bool late)
 		// we don't need to have 256 chars to work with here as most strings are far smaller than that
 		
 		// fgets stops at n - 1 aka 127
+		//Read in to temp var
 		char* temp = new char[128];
 		if (fgets(temp, 128, file) != NULL)
 		{

--- a/extension.cpp
+++ b/extension.cpp
@@ -87,7 +87,6 @@ bool Cleaner::SDK_OnLoad(char *error, size_t maxlength, bool late)
 	}
 	rootconsole->ConsolePrint("[CLEANER] %i strings added from cleaner.cfg", szStrings.size());
 	cleanerConfig.close();
-	delete [] szPath;
 
 	// init our detours
 	#if SOURCE_ENGINE >= SE_LEFT4DEAD2

--- a/extension.cpp
+++ b/extension.cpp
@@ -22,7 +22,7 @@ vector<string> szStrings;
 		{
 			// make sure we're stripping at least 2 or more chars just in case we accidentally inhale a \0
 			// also there's no reason to strip a single char ever
-			if (szStrings[i].length() >= 2 && szStrings[i].find(pMessage) != string::npos)
+			if (szStrings[i].length() >= 2 && strstr(pMessage, szStrings[i].c_str()) != 0)
 			{
 				return LR_CONTINUE;
 			}
@@ -36,7 +36,7 @@ vector<string> szStrings;
 		{
 			// make sure we're stripping at least 2 or more chars just in case we accidentally inhale a \0
 			// also there's no reason to strip a single char ever
-			if (szStrings[i].length() >= 2 && szStrings[i].find(text) != string::npos)
+			if (szStrings[i].length() >= 2 && strstr(text, szStrings[i].c_str()) != 0)
 			{
 				return SPEW_CONTINUE;
 			}

--- a/extension.cpp
+++ b/extension.cpp
@@ -36,7 +36,7 @@ vector<string> szStrings;
 		{
 			// make sure we're stripping at least 2 or more chars just in case we accidentally inhale a \0
 			// also there's no reason to strip a single char ever
-			if (szStrings[i].length() >= 2 && szStrings[i].find(pMessage) != string::npos)
+			if (szStrings[i].length() >= 2 && szStrings[i].find(text) != string::npos)
 			{
 				return SPEW_CONTINUE;
 			}

--- a/extension.cpp
+++ b/extension.cpp
@@ -104,11 +104,11 @@ bool Cleaner::SDK_OnLoad(char *error, size_t maxlength, bool late)
 			// don't strip tiny (including 0 len or less) strings
 			if (thisstring.length() <= 1)
 			{
-				rootconsole->ConsolePrint("[CLEANER] Not stripping string on -> L%i with 1 or less length! Length: %i", g_iStrings+1, strlen(c_thisstring));
+				rootconsole->ConsolePrint("[CLEANER] Not stripping string on -> L%i with 1 or less length! Length: %i", g_iStrings+1, thisstring.length());
 			}
 			else
 			{
-				rootconsole->ConsolePrint("[CLEANER] Stripping string on     -> L%i: \"%s\" - length: %i", g_iStrings+1, c_thisstring, strlen(c_thisstring));
+				rootconsole->ConsolePrint("[CLEANER] Stripping string on     -> L%i: \"%s\" - length: %i", g_iStrings+1, thisstring.c_str(), thisstring.length());
 			}
 			g_szStrings[g_iStrings] = new char[thisstring.length()];
 			strcpy(g_szStrings[g_iStrings], thisstring.c_str());

--- a/extension.cpp
+++ b/extension.cpp
@@ -88,25 +88,20 @@ bool Cleaner::SDK_OnLoad(char *error, size_t maxlength, bool late)
 	while (!feof(file))
 	{
 		// we don't need to have 256 chars to work with here as most strings are far smaller than that
-		g_szStrings[g_iStrings] = new char[128];
+		
 		// fgets stops at n - 1 aka 127
-		if (fgets(g_szStrings[g_iStrings], 128, file) != NULL)
+		char* temp = new char[128];
+		if (fgets(temp, 128, file) != NULL)
 		{
 			// make things a little easier on ourselves
-			std::string thisstring = g_szStrings[g_iStrings];
+			std::string thisstring = string(temp);
 
 			// significantly more robust way of stripping evil chars from our string so we don't crash
 			// when we try to strip them. this includes newlines, control chars, non ascii unicde, etc.
 			stripBadChars(thisstring);
 
-			// copy our std::string back to char*
-			// Disgusting.
-			char* c_thisstring = &thisstring[0];
-
-			int len = strlen(c_thisstring);
-
 			// don't strip tiny (including 0 len or less) strings
-			if (len <= 1)
+			if (thisstring.length() <= 1)
 			{
 				rootconsole->ConsolePrint("[CLEANER] Not stripping string on -> L%i with 1 or less length! Length: %i", g_iStrings+1, strlen(c_thisstring));
 			}
@@ -114,11 +109,12 @@ bool Cleaner::SDK_OnLoad(char *error, size_t maxlength, bool late)
 			{
 				rootconsole->ConsolePrint("[CLEANER] Stripping string on     -> L%i: \"%s\" - length: %i", g_iStrings+1, c_thisstring, strlen(c_thisstring));
 			}
-
-			strcpy(g_szStrings[g_iStrings], c_thisstring);
+			g_szStrings[g_iStrings] = new char[thisstring.length()];
+			strcpy(g_szStrings[g_iStrings], c_thisstring.c_str());
 
 			++g_iStrings;
 		}
+		delete [] temp;
 	}
 	fclose(file);
 

--- a/extension.cpp
+++ b/extension.cpp
@@ -111,7 +111,7 @@ bool Cleaner::SDK_OnLoad(char *error, size_t maxlength, bool late)
 				rootconsole->ConsolePrint("[CLEANER] Stripping string on     -> L%i: \"%s\" - length: %i", g_iStrings+1, c_thisstring, strlen(c_thisstring));
 			}
 			g_szStrings[g_iStrings] = new char[thisstring.length()];
-			strcpy(g_szStrings[g_iStrings], c_thisstring.c_str());
+			strcpy(g_szStrings[g_iStrings], thisstring.c_str());
 
 			++g_iStrings;
 		}


### PR DESCRIPTION
This PR changes how the configuration is loaded as well as how the strings loaded are stored and used.
This is because we experienced double free errors which may have been caused from our manual char[]* deletions.
std::string is now used to avoid such errors.

A vector is also used to avoid us needing to know the file line num beforehand.

Example of old crash, note how even the lines reported does not match:
```
[CLEANER] 7 lines in cleaner.cfg
[CLEANER] Stripping string on     -> L1: "DataTable warning" - length: 17
[CLEANER] Stripping string on     -> L2: "CreateFragmentsFromFile" - length: 23
[CLEANER] Stripping string on     -> L3: "CSoundEmitterSystemBase" - length: 23
[CLEANER] Stripping string on     -> L4: "ENTITY_CHANGE_NONE" - length: 18
[CLEANER] Stripping string on     -> L5: "EmitSound:" - length: 10
[CLEANER] Stripping string on     -> L6: "EntSelectSpawnPoint" - length: 19
[CLEANER] Stripping string on     -> L7: "CMaterial::PrecacheVars: error" - length: 30
[CLEANER] Stripping string on     -> L8: "SOLID_VPHYSICS static prop with no vphysics model!" - length: 50
double free or corruption (out)
```