### PR TITLE
feat(github-ci): release job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,11 +3,17 @@ name: build
 on:
   push:
     branches:
+      - main
       - master
+    tags:
+      - '*'
     paths-ignore:
       - LICENSE
       - README.md
   pull_request:
+    branches:
+      - main
+      - master
     paths-ignore:
       - LICENSE
       - README.md
@@ -152,5 +158,36 @@ jobs:
       - name: Uploading package
         uses: actions/upload-artifact@v3
         with:
-          name: cleaner-sm${{ matrix.sm_version }}-${{ matrix.os_short }}-${{ env.GITHUB_SHA_SHORT }}
+          name: ${{ github.event.repository.name }}-${{ matrix.sm_version }}-${{ matrix.os_short }}
           path: src/build/package
+
+  release:
+    name: Release
+    if: startsWith(github.ref, 'refs/tags/')
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v3
+
+      - name: Package
+        run: |
+          version=`echo $GITHUB_REF | sed "s/refs\/tags\///"`
+          ls -Rall
+          for folder in ${{ github.event.repository.name }}*; do
+            if [ -d "$folder" ]; then
+              echo "Processing folder: $folder"
+              cd $folder
+              tar -czf ../$folder.tar.gz -T <(\ls -1)
+              cd ..
+            fi
+          done
+
+      - name: Release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: '*.tar.gz'
+          tag: ${{ github.ref }}
+          file_glob: true


### PR DESCRIPTION
Adds a release job so that when you create a new tag, it automatically creates a release like this:
- https://github.com/srcdslab/sm-ext-cleaner/releases/tag/v1.3.0-dev0