### PR TITLE
chore(ci): pin to ubuntu 20.04 for older glibc compat

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-latest
+          - ubuntu-20.04
           - windows-latest
 
         sm_version:
@@ -44,7 +44,7 @@ jobs:
           - sm_version: "master"
             sm_branch: "master"
 
-          - os: ubuntu-latest
+          - os: ubuntu-20.04
             os_short: linux
 
           - os: windows-latest


### PR DESCRIPTION
Fixes #18 

```
ubuntu@game:/tmp/cleanerr$ ldd cleaner.css.so
./cleaner.css.so: /lib32/libstdc++.so.6: version `GLIBCXX_3.4.29' not found (required by ./cleaner.css.so)
./cleaner.css.so: /lib32/libc.so.6: version `GLIBC_2.32' not found (required by ./cleaner.css.so)
./cleaner.css.so: /lib32/libc.so.6: version `GLIBC_2.34' not found (required by ./cleaner.css.so)
```

```
ubuntu@game:~$ cat /etc/os-release
NAME="Ubuntu"
VERSION="20.04.6 LTS (Focal Fossa)"
```